### PR TITLE
fix(wxml-parser): Cannot create property '_type' on string xx

### DIFF
--- a/src/core/wxapkg/wxml-parser/parseWxml.ts
+++ b/src/core/wxapkg/wxml-parser/parseWxml.ts
@@ -333,7 +333,7 @@ function elemToString(elem, dep, moreInfo = false) {
   if (isTextTag(elem)) {
     //In comment, you can use typify text node, which beautify its code, but may destroy ui.
     //So, we use a "hack" way to solve this problem by letting typify program stop when face textNode
-    let str: any = String(wxmlify(elem.content, true))
+    let str: any = new String(wxmlify(elem.content, true))
     str.textNode = 1
     return wxmlify(str, true) //indent.repeat(dep)+wxmlify(elem.content.trim(),true)+"\n";
   }

--- a/src/core/wxapkg/wxml-parser/parseZArray.ts
+++ b/src/core/wxapkg/wxml-parser/parseZArray.ts
@@ -222,7 +222,7 @@ function restoreSingle(ops, withScope = false) {
             ans = enBrace('__unTestedGetValue:' + enBrace(jsoToWxon(ops), '['), '{')
             break
           case 3:
-            ans = String(ops[1][1])
+            ans = new String(ops[1][1])
             ans._type = 'var'
             break
           default:


### PR DESCRIPTION
修复执行yarn run build 之后的 dist\index.js，运行会出现 String 对象被转成 string 类型导致无法设置 '_type' property 的错误。

详细内容见 https://github.com/r3x5ur/unveilr/pull/107